### PR TITLE
bugfix: change path.join to use path.posix.join when passed to globby

### DIFF
--- a/packages/shared/src/markdoc/read.ts
+++ b/packages/shared/src/markdoc/read.ts
@@ -95,7 +95,7 @@ export async function readAll<T extends z.ZodTypeAny>({
   directory: string;
   frontmatterSchema: T;
 }) {
-  const pathToDir = path.join(contentDirectory, directory);
+  const pathToDir = path.posix.join(contentDirectory, directory);
   const paths = await globby(`${pathToDir}/*.md`);
 
   return Promise.all(paths.map((path) => read({ filepath: path, schema })));

--- a/templates/bubblegum/src/lib/markdoc/read.ts
+++ b/templates/bubblegum/src/lib/markdoc/read.ts
@@ -95,7 +95,7 @@ export async function readAll<T extends z.ZodTypeAny>({
   directory: string;
   frontmatterSchema: T;
 }) {
-  const pathToDir = path.join(contentDirectory, directory);
+  const pathToDir = path.posix.join(contentDirectory, directory);
   const paths = await globby(`${pathToDir}/*.md`);
 
   return Promise.all(paths.map((path) => read({ filepath: path, schema })));

--- a/templates/minimal/src/lib/markdoc/read.ts
+++ b/templates/minimal/src/lib/markdoc/read.ts
@@ -95,7 +95,7 @@ export async function readAll<T extends z.ZodTypeAny>({
   directory: string;
   frontmatterSchema: T;
 }) {
-  const pathToDir = path.join(contentDirectory, directory);
+  const pathToDir = path.posix.join(contentDirectory, directory);
   const paths = await globby(`${pathToDir}/*.md`);
 
   return Promise.all(paths.map((path) => read({ filepath: path, schema })));

--- a/templates/newspaper/src/lib/markdoc/read.ts
+++ b/templates/newspaper/src/lib/markdoc/read.ts
@@ -95,7 +95,7 @@ export async function readAll<T extends z.ZodTypeAny>({
   directory: string;
   frontmatterSchema: T;
 }) {
-  const pathToDir = path.join(contentDirectory, directory);
+  const pathToDir = path.posix.join(contentDirectory, directory);
   const paths = await globby(`${pathToDir}/*.md`);
 
   return Promise.all(paths.map((path) => read({ filepath: path, schema })));

--- a/templates/sleek/src/lib/markdoc/read.ts
+++ b/templates/sleek/src/lib/markdoc/read.ts
@@ -95,7 +95,7 @@ export async function readAll<T extends z.ZodTypeAny>({
   directory: string;
   frontmatterSchema: T;
 }) {
-  const pathToDir = path.join(contentDirectory, directory);
+  const pathToDir = path.posix.join(contentDirectory, directory);
   const paths = await globby(`${pathToDir}/*.md`);
 
   return Promise.all(paths.map((path) => read({ filepath: path, schema })));


### PR DESCRIPTION
I have changed each instance of  to explicitly use  when that path is passed into globby. This is to fix an issue where, on windows platforms, a windows path is passed into globby. This is not allowed according to globby's documentation and was causing all directories in  to not load correctly on the website.

Closes #4 